### PR TITLE
Allow selectZoom to be adaptive

### DIFF
--- a/demo/plugins/select.html
+++ b/demo/plugins/select.html
@@ -16,6 +16,12 @@
 
         <label for="y">Y</label>
         <input type="checkbox" id="y" name="y">
+
+        <label for="threshold-x">thresholdX</label>
+        <input type="number" size="4" id="threshold-x" name="thresholdX" value="20" min="0">
+
+        <label for="threshold-y">thresholdY</label>
+        <input type="number" size="4" id="threshold-y" name="thresholdY" value="20" min="0">
     </form>
 
     <script src="https://cdn.jsdelivr.net/npm/d3-array@3"></script>
@@ -54,9 +60,11 @@
 
         const form = document.querySelector('form');
         function syncSelectZoom() {
-            const { x, y } = form;
+            const { x, y, thresholdX, thresholdY } = form;
             chart.plugins.selectZoom.options.enableX = x.checked;
             chart.plugins.selectZoom.options.enableY = y.checked;
+            chart.plugins.selectZoom.options.thresholdX = thresholdX.value;
+            chart.plugins.selectZoom.options.thresholdY = thresholdY.value;
         }
         form.addEventListener('change', syncSelectZoom);
         syncSelectZoom();

--- a/src/plugins_extra/selectZoom.ts
+++ b/src/plugins_extra/selectZoom.ts
@@ -5,6 +5,8 @@ export interface SelectZoomOptions {
     mouseButtons: number;
     enableX: boolean;
     enableY: boolean;
+    thresholdX: number;
+    thresholdY: number;
     cancelOnSecondPointer: boolean;
 }
 
@@ -12,6 +14,8 @@ const defaultOptions = {
     mouseButtons: 1,
     enableX: true,
     enableY: true,
+    thresholdX: 0,
+    thresholdY: 0,
     cancelOnSecondPointer: false,
 } as const;
 
@@ -95,9 +99,12 @@ export class SelectZoom {
             return;
         const p = this.getPoint(ev);
 
-        if (this.options.enableX) {
-            const x = Math.min(this.start.p.x, p.x);
-            const w = Math.abs(this.start.p.x - p.x);
+        const x = Math.min(this.start.p.x, p.x);
+        const w = Math.abs(this.start.p.x - p.x);
+        const y = Math.min(this.start.p.y, p.y);
+        const h = Math.abs(this.start.p.y - p.y);
+
+        if (this.options.enableX && ((w >= h) || (w >= this.options.thresholdX))) {
             this.visual.x.baseVal.value = x;
             this.visual.width.baseVal.value = w;
         } else {
@@ -105,9 +112,7 @@ export class SelectZoom {
             this.visual.setAttribute('width', '100%');
         }
 
-        if (this.options.enableY) {
-            const y = Math.min(this.start.p.y, p.y);
-            const h = Math.abs(this.start.p.y - p.y);
+        if (this.options.enableY && ((h > w) || (h >= this.options.thresholdY))) {
             this.visual.y.baseVal.value = y;
             this.visual.height.baseVal.value = h;
         } else {
@@ -126,7 +131,7 @@ export class SelectZoom {
         if (this.options.enableX) {
             const x1 = Math.min(this.start.p.x, p.x);
             const x2 = Math.max(this.start.p.x, p.x);
-            if (x2 - x1 > 0) {
+            if (x2 - x1 > this.options.thresholdX) {
                 const newDomain = [
                     this.chart.model.xScale.invert(x1),
                     this.chart.model.xScale.invert(x2),
@@ -139,7 +144,7 @@ export class SelectZoom {
         if (this.options.enableY) {
             const y1 = Math.max(this.start.p.y, p.y);
             const y2 = Math.min(this.start.p.y, p.y);
-            if (y1 - y2 > 0) {
+            if (y1 - y2 > this.options.thresholdY) {
                 const newDomain = [
                     this.chart.model.yScale.invert(y1),
                     this.chart.model.yScale.invert(y2),

--- a/src/plugins_extra/selectZoom.ts
+++ b/src/plugins_extra/selectZoom.ts
@@ -54,6 +54,8 @@ export class SelectZoom {
     }
 
     private start: {p: Point, id: number} | null = null;
+    private selectX: boolean = false;
+    private selectY: boolean = false;
 
     private reset() {
         if (this.start === null)
@@ -105,10 +107,10 @@ export class SelectZoom {
         const h = Math.abs(this.start.p.y - p.y);
         const minW = Math.min(h, this.options.thresholdX);
         const minH = Math.min(w, this.options.thresholdY);
-        const selectX = w >= minW || !this.options.enableY;
-        const selectY = h >= minH || !this.options.enableX;
+        this.selectX = w >= minW || !this.options.enableY;
+        this.selectY = h >= minH || !this.options.enableX;
 
-        if (this.options.enableX && selectX) {
+        if (this.options.enableX && this.selectX) {
             this.visual.x.baseVal.value = x;
             this.visual.width.baseVal.value = w;
         } else {
@@ -116,7 +118,7 @@ export class SelectZoom {
             this.visual.setAttribute('width', '100%');
         }
 
-        if (this.options.enableY && selectY) {
+        if (this.options.enableY && this.selectY) {
             this.visual.y.baseVal.value = y;
             this.visual.height.baseVal.value = h;
         } else {
@@ -134,15 +136,9 @@ export class SelectZoom {
         const x2 = Math.max(this.start.p.x, p.x);
         const y1 = Math.max(this.start.p.y, p.y);
         const y2 = Math.min(this.start.p.y, p.y);
-        const w = Math.abs(x2 - x1);
-        const h = Math.abs(y2 - y1);
-        const minW = Math.min(h, this.options.thresholdX);
-        const minH = Math.min(w, this.options.thresholdY);
-        const selectX = w >= minW || !this.options.enableY;
-        const selectY = h >= minH || !this.options.enableX;
 
         let changed = false;
-        if (this.options.enableX && selectX && x2 != x1) {
+        if (this.options.enableX && this.selectX && x2 != x1) {
             const newDomain = [
                 this.chart.model.xScale.invert(x1),
                 this.chart.model.xScale.invert(x2),
@@ -151,7 +147,7 @@ export class SelectZoom {
             this.chart.options.xRange = null;
             changed = true;
         }
-        if (this.options.enableY && selectY && y2 != y1) {
+        if (this.options.enableY && this.selectY && y2 != y1) {
             const newDomain = [
                 this.chart.model.yScale.invert(y1),
                 this.chart.model.yScale.invert(y2),

--- a/src/plugins_extra/selectZoom.ts
+++ b/src/plugins_extra/selectZoom.ts
@@ -108,7 +108,7 @@ export class SelectZoom {
         const minW = Math.min(h, this.options.thresholdX);
         const minH = Math.min(w, this.options.thresholdY);
         this.selectX = w >= minW || !this.options.enableY;
-        this.selectY = h >= minH || !this.options.enableX;
+        this.selectY = h > minH || !this.options.enableX;
 
         if (this.options.enableX && this.selectX) {
             this.visual.x.baseVal.value = x;

--- a/src/plugins_extra/selectZoom.ts
+++ b/src/plugins_extra/selectZoom.ts
@@ -103,16 +103,16 @@ export class SelectZoom {
 
         const x = Math.min(this.start.p.x, p.x);
         const y = Math.min(this.start.p.y, p.y);
-        const w = Math.abs(this.start.p.x - p.x);
-        const h = Math.abs(this.start.p.y - p.y);
-        const minW = Math.min(h, this.options.thresholdX);
-        const minH = Math.min(w, this.options.thresholdY);
-        this.selectX = w >= minW || !this.options.enableY;
-        this.selectY = h > minH || !this.options.enableX;
+        const width = Math.abs(this.start.p.x - p.x);
+        const height = Math.abs(this.start.p.y - p.y);
+        const minWidth = Math.min(height, this.options.thresholdX);
+        const minHeight = Math.min(width, this.options.thresholdY);
+        this.selectX = width >= minWidth || !this.options.enableY;
+        this.selectY = height > minHeight || !this.options.enableX;
 
         if (this.options.enableX && this.selectX) {
             this.visual.x.baseVal.value = x;
-            this.visual.width.baseVal.value = w;
+            this.visual.width.baseVal.value = width;
         } else {
             this.visual.setAttribute('x', '0');
             this.visual.setAttribute('width', '100%');
@@ -120,7 +120,7 @@ export class SelectZoom {
 
         if (this.options.enableY && this.selectY) {
             this.visual.y.baseVal.value = y;
-            this.visual.height.baseVal.value = h;
+            this.visual.height.baseVal.value = height;
         } else {
             this.visual.setAttribute('y', '0');
             this.visual.setAttribute('height', '100%');

--- a/src/plugins_extra/selectZoom.ts
+++ b/src/plugins_extra/selectZoom.ts
@@ -100,11 +100,15 @@ export class SelectZoom {
         const p = this.getPoint(ev);
 
         const x = Math.min(this.start.p.x, p.x);
-        const w = Math.abs(this.start.p.x - p.x);
         const y = Math.min(this.start.p.y, p.y);
+        const w = Math.abs(this.start.p.x - p.x);
         const h = Math.abs(this.start.p.y - p.y);
+        const minW = Math.min(h, this.options.thresholdX);
+        const minH = Math.min(w, this.options.thresholdY);
+        const selectX = w >= minW || !this.options.enableY;
+        const selectY = h >= minH || !this.options.enableX;
 
-        if (this.options.enableX && ((w >= h) || (w >= this.options.thresholdX))) {
+        if (this.options.enableX && selectX) {
             this.visual.x.baseVal.value = x;
             this.visual.width.baseVal.value = w;
         } else {
@@ -112,7 +116,7 @@ export class SelectZoom {
             this.visual.setAttribute('width', '100%');
         }
 
-        if (this.options.enableY && ((h > w) || (h >= this.options.thresholdY))) {
+        if (this.options.enableY && selectY) {
             this.visual.y.baseVal.value = y;
             this.visual.height.baseVal.value = h;
         } else {
@@ -130,9 +134,15 @@ export class SelectZoom {
         const x2 = Math.max(this.start.p.x, p.x);
         const y1 = Math.max(this.start.p.y, p.y);
         const y2 = Math.min(this.start.p.y, p.y);
+        const w = Math.abs(x2 - x1);
+        const h = Math.abs(y2 - y1);
+        const minW = Math.min(h, this.options.thresholdX);
+        const minH = Math.min(w, this.options.thresholdY);
+        const selectX = w >= minW || !this.options.enableY;
+        const selectY = h >= minH || !this.options.enableX;
 
         let changed = false;
-        if (this.options.enableX && (x2 - x1 > 0) && ((x2 - x1 >= y1 - y2) || (x2 - x1 > this.options.thresholdX))) {
+        if (this.options.enableX && selectX && x2 != x1) {
             const newDomain = [
                 this.chart.model.xScale.invert(x1),
                 this.chart.model.xScale.invert(x2),
@@ -141,7 +151,7 @@ export class SelectZoom {
             this.chart.options.xRange = null;
             changed = true;
         }
-        if (this.options.enableY && (y1 - y2 > 0) && ((y1 - y2 > x2 - x1) || (y1 - y2 > this.options.thresholdY))) {
+        if (this.options.enableY && selectY && y2 != y1) {
             const newDomain = [
                 this.chart.model.yScale.invert(y1),
                 this.chart.model.yScale.invert(y2),

--- a/src/plugins_extra/selectZoom.ts
+++ b/src/plugins_extra/selectZoom.ts
@@ -126,33 +126,29 @@ export class SelectZoom {
             return;
 
         const p = this.getPoint(ev);
+        const x1 = Math.min(this.start.p.x, p.x);
+        const x2 = Math.max(this.start.p.x, p.x);
+        const y1 = Math.max(this.start.p.y, p.y);
+        const y2 = Math.min(this.start.p.y, p.y);
 
         let changed = false;
-        if (this.options.enableX) {
-            const x1 = Math.min(this.start.p.x, p.x);
-            const x2 = Math.max(this.start.p.x, p.x);
-            if (x2 - x1 > this.options.thresholdX) {
-                const newDomain = [
-                    this.chart.model.xScale.invert(x1),
-                    this.chart.model.xScale.invert(x2),
-                ];
-                this.chart.model.xScale.domain(newDomain);
-                this.chart.options.xRange = null;
-                changed = true;
-            }
+        if (this.options.enableX && (x2 - x1 > 0) && ((x2 - x1 >= y1 - y2) || (x2 - x1 > this.options.thresholdX))) {
+            const newDomain = [
+                this.chart.model.xScale.invert(x1),
+                this.chart.model.xScale.invert(x2),
+            ];
+            this.chart.model.xScale.domain(newDomain);
+            this.chart.options.xRange = null;
+            changed = true;
         }
-        if (this.options.enableY) {
-            const y1 = Math.max(this.start.p.y, p.y);
-            const y2 = Math.min(this.start.p.y, p.y);
-            if (y1 - y2 > this.options.thresholdY) {
-                const newDomain = [
-                    this.chart.model.yScale.invert(y1),
-                    this.chart.model.yScale.invert(y2),
-                ];
-                this.chart.model.yScale.domain(newDomain);
-                this.chart.options.yRange = null;
-                changed = true;
-            }
+        if (this.options.enableY && (y1 - y2 > 0) && ((y1 - y2 > x2 - x1) || (y1 - y2 > this.options.thresholdY))) {
+            const newDomain = [
+                this.chart.model.yScale.invert(y1),
+                this.chart.model.yScale.invert(y2),
+            ];
+            this.chart.model.yScale.domain(newDomain);
+            this.chart.options.yRange = null;
+            changed = true;
         }
         if (changed)
             this.chart.model.requestRedraw();


### PR DESCRIPTION
When both axes are enabled for the selectZoom, it's quite inconvenient to zoom along only one axis. Making the zoom adaptive allows only one axis to be zoomed when the selection along the other axis is below a certain threshold. As an example, see the plot "X or Y (adaptive + omni)" here https://leeoniya.github.io/uPlot/demos/zoom-variations.html.    

This merge request implements an adaptive select zoom that can be configured with the options `thresholdX` and `thresholdY`. By default both thresholds are zero which recovers the regular select zoom. When both thresholds are set to a finite value, the zoom selection will ignore the axis with the smaller selection if it is below its respective threshold.